### PR TITLE
Add editor instructions for Sublime Text 2

### DIFF
--- a/src/pages/editors.haml
+++ b/src/pages/editors.haml
@@ -32,3 +32,5 @@
     * **[TextMate/E Text Editor](http://github.com/handcrafted/handcrafted-haml-textmate-bundle)** by [Adam Stacoviak](http://www.adamstacoviak.com). There's also an [official](http://svn.textmate.org/trunk/Bundles/Ruby%20Haml.tmbundle) but out-of-date bundle by [Kevin Ballard](http://kevin.sb.org), and many [GitHub forks](http://github.com/douglasjarquin/ruby-haml-tmbundle/network) of that bundle.
 
     * **[Vim](http://github.com/tpope/vim-haml)** by [Tim Pope](http://www.stopwritingramblingcommitmessages.com). There's also an [official](http://www.vim.org/scripts/script.php?script_id=1773) but out-of-date mode by [Dmitry Ilyashevich](http://github.com/dmitry-ilyashevich).
+
+    * **[Sublime Text 2](https://github.com/phuibonhoa/handcrafted-haml-textmate-bundle)** by [Adam Stacoviak](http://www.adamstacoviak.com) and adapted by [Philippe Huibonhoa](http://github.com/phuibonhoa). It's available via the [Sublime Package Control](http://wbond.net/sublime_packages/package_control) plugin as well.


### PR DESCRIPTION
Many people use Sublime Text 2 these days, and it's very easy to install via Sublime Package Control.
