### PR TITLE
Point to GitHub changelog instead of outdated yard

### DIFF
--- a/src/pages/index.haml
+++ b/src/pages/index.haml
@@ -11,7 +11,7 @@
       = link 'Download Haml', '/download.html', class: 'btn'
       %b
         Latest: <strong>#{Haml::VERSION}</strong> -
-        %strong= link "What's New?", '/docs/yardoc/file.CHANGELOG.html'
+        %strong= link "What's New?", 'https://github.com/haml/haml/blob/master/CHANGELOG.md'
 
 .sample
   .box


### PR DESCRIPTION
See:
- http://haml.info/docs/yardoc/file.CHANGELOG.html
- https://github.com/haml/haml/blob/master/CHANGELOG.md 

The Yard page looks abandoned because the last release listed there is 4.0.7 
from 2015 while 5.0.4 from October 2017 is on the GitHub changelog. 

Since the yard changelog is linked to from haml.info's homepage it makes 
Haml look abandoned. Perhaps updating yard is an alternative solution but it 
seems simpler to just point to the GitHub changelog which is bound to be 
more up-to-date anyway.