### PR TITLE
Bundle update with the haml version set to 5.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem "sass", '~> 3.2.19'
 gem "staticmatic"
 gem "maruku"
-gem "haml", "~> 5.0.0"
+gem "haml", "~> 5.0.4"
 gem "haml-contrib"
 gem "compass", "0.11.7"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    chunky_png (1.3.8)
+    chunky_png (1.3.10)
     compass (0.11.7)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.1)
     fssm (0.2.10)
-    haml (5.0.3)
+    haml (5.0.4)
       temple (>= 0.8.0)
       tilt
     haml-contrib (1.0.0.1)
       haml (>= 3.2.0.alpha.13)
-    kramdown (1.14.0)
+    kramdown (1.17.0)
     maruku (0.7.3)
-    rack (2.0.3)
-    rake (12.0.0)
+    rack (2.0.5)
+    rake (12.3.1)
     sass (3.2.19)
     staticmatic (0.11.1)
       compass (>= 0.10.0)
@@ -23,14 +23,14 @@ GEM
       rack (>= 1.0)
     temple (0.8.0)
     tilt (2.0.8)
-    yard (0.9.9)
+    yard (0.9.16)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   compass (= 0.11.7)
-  haml (~> 5.0.0)
+  haml (~> 5.0.4)
   haml-contrib
   kramdown
   maruku
@@ -40,4 +40,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.15.4
+   1.16.2


### PR DESCRIPTION
Bumped the Haml version to 5.0.4 so it supports the use of Ruby 2.5 and ran `bundle update`