### PR TITLE
Change the Haml branch so YARD generates the most recent documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,13 +58,13 @@ end
 task :haml => ".haml" do
   Dir.chdir(".haml") do
     sh %{git fetch}
-    sh %{git checkout origin/stable}
+    sh %{git checkout origin/master}
   end
 end
 
 file ".haml" do
   sh %{git clone git://github.com/haml/haml.git .haml}
   Dir.chdir(".haml") do
-    sh %{git checkout origin/stable}
+    sh %{git checkout origin/master}
   end
 end


### PR DESCRIPTION
Changed the Haml branch in the rake task to master since the [stable branch](https://github.com/haml/haml/tree/stable) hasn't been updated in some time. Now the most recent documentation will be available in the Haml site after rebuilding it.

/cc @amatsuda 